### PR TITLE
feat: Add SSH config as an option

### DIFF
--- a/completions/emc.fish
+++ b/completions/emc.fish
@@ -7,6 +7,7 @@ complete --command $EMC_CMD --no-files --arguments fish --condition "__fish_use_
 complete --command $EMC_CMD --no-files --arguments git --condition "__fish_use_subcommand" --description "Opens the Git config file."
 complete --command $EMC_CMD --no-files --arguments gpg --condition "__fish_use_subcommand" --description "Opens the GPG config file."
 complete --command $EMC_CMD --no-files --arguments gpga --condition "__fish_use_subcommand" --description "Opens the GPG agent config file."
+complete --command $EMC_CMD --no-files --arguments ssh --condition "__fish_use_subcommand" --description "Opens the SSH config file."
 complete --command $EMC_CMD --no-files --arguments nvim --condition "__fish_use_subcommand" --description "Opens the Neovim config file."
 complete --command $EMC_CMD --no-files --arguments starship --condition "__fish_use_subcommand" --description "Opens the starship config file."
 complete --command $EMC_CMD --no-files --arguments tmux --condition "__fish_use_subcommand" --description "Opens the tmux config file."

--- a/functions/__emc.fish
+++ b/functions/__emc.fish
@@ -27,6 +27,9 @@ function __emc -d "Edit My Config"
         case 'gpga'
             _emc_gpga
 
+        case 'ssh'
+            _emc_ssh
+
         case 'nvim'
             _emc_nvim
 
@@ -62,6 +65,7 @@ function _emc_help
     echo -e "   git        Opens the Git config file."
     echo -e "   gpg        Opens the GPG config file."
     echo -e "   gpga       Opens the GPG agent config file."
+    echo -e "   ssh        Opens the SSH config file."
     echo -e "   nvim       Opens the Neovim config file."
     echo -e "   starship   Opens the starship config file."
     echo -e "   tmux       Opens the tmux config file."
@@ -119,6 +123,16 @@ function _emc_gpga
         command $EMC_EDITOR $file
     else
         echo -e (set_color red --bold)"✗ The" (set_color --underline)"~/.gnupg/gpg-agent.conf"(set_color normal) (set_color red --bold)"file does not exist."(set_color normal)
+    end
+end
+
+function _emc_ssh
+    set file $HOME/.ssh/config
+    if test -f $file
+        echo -e (set_color cyan)"→ Opening" (set_color --underline)"~/.ssh/config"(set_color normal) (set_color cyan)"file."(set_color normal)
+        command $EMC_EDITOR $file
+    else
+        echo -e (set_color red --bold)"✗ The" (set_color --underline)"~/.ssh/config"(set_color normal) (set_color red --bold)"file does not exist."(set_color normal)
     end
 end
 


### PR DESCRIPTION
<!-- First of all thanks so much for taking the time to open a pull request and help the project. It's because of people like you that we love working on this project. -->

Which issue(s) this PR fixes (If applicable): #
<!-- Link to relevant GitHub issue if applicable. -->

### Checklist
<!-- Please ensure you've completed the following steps by replacing [ ] with [x] -->
* [x ] I have followed the [Contribution Guidelines](https://github.com/demartini/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/demartini/.github/blob/main/CODE_OF_CONDUCT.md).
* [x ] I have commented my code following the [Styleguide](https://github.com/demartini/.github/blob/main/STYLEGUIDE.md).
* [x ] Relevant documentation is changed or added.
* [x ] This is **NOT A BREAKING CHANGE**.

### What kind of change does this PR introduce?

* [ ] Bugfix.
* [x ] Feature.
* [ ] Code style update (formatting).
* [ ] Refactoring (no functional changes).
* [ ] Build or CI related changes.
* [ ] Documentation content changes.
* [ ] Project automation.
* [ ] Other...
  * [ ] Please describe:

### Description of Change

This PR adds the SSH config to the list of config files supported. The SSH config is frequently changed to add new hosts, so a shortcut function can be helpful.

The addition follows the model of all other configs through the addition of an `_emc_ssh` function. It also updates the USAGE string and `fish` completions.

### What is the current behavior?

`emc.fish` does not support `ssh` config

### What is the new behavior?

`emc.fish` will now support `ssh` config using the argument `ssh`

### Does this PR introduce a breaking change?

No

### Screenshots

### Other Information


